### PR TITLE
Fix null handling in presence rule.

### DIFF
--- a/src/__tests__/presence.spec.js
+++ b/src/__tests__/presence.spec.js
@@ -11,6 +11,7 @@ function test (value) {
 describe('Validator: presence', function() {
   it('should be invalid when `value` is empty', function() {
     assert.equal(ERROR_ID, test())
+    assert.equal(ERROR_ID, test(null))
     assert.equal(ERROR_ID, test(''))
     assert.equal(ERROR_ID, test('   '))
     assert.equal(ERROR_ID, test(' \n \t '))

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,6 +18,7 @@ export function regFormat (options, reg, messageId) {
 
 export function prepare (ifCond, unlessCond, allowBlank, func) {
   return function (value='', allValues={}) {
+    value = (value === null) ? '' : value; // ES2015 default parameters only replace 'undefined' (not 'null')
     value = '' + value
 
     if ((null != allowBlank ? allowBlank : DEFAULT_OPTIONS.allowBlank) && !value.trim()) {


### PR DESCRIPTION
ES2015 default parameters only replace 'undefined' (not 'null')