### PR TITLE
Allow custom validators to use formatMessage

### DIFF
--- a/src/add-validator.js
+++ b/src/add-validator.js
@@ -11,15 +11,13 @@ export default function addValidator ({ validator, defaultMessage, defaultMsg })
 
     return prepare(options.if, options.unless, options.allowBlank, function (value, allValues) {
       let result = validator(options, value, allValues)
-      if ('boolean' !== typeof result) {
-        if (result !== null && typeof result === 'object') {
-          return Validators.formatMessage(result)
-        }
-        return result
-      }
       if (!result) {
         return Validators.formatMessage(msg)
       }
+      if (typeof result === 'object') {
+        return Validators.formatMessage(result)
+      }
+      return result
     })
   })
 }

--- a/src/add-validator.js
+++ b/src/add-validator.js
@@ -12,6 +12,9 @@ export default function addValidator ({ validator, defaultMessage, defaultMsg })
     return prepare(options.if, options.unless, options.allowBlank, function (value, allValues) {
       let result = validator(options, value, allValues)
       if ('boolean' !== typeof result) {
+        if (result !== null && typeof result === 'object') {
+          return Validators.formatMessage(result)
+        }
         return result
       }
       if (!result) {


### PR DESCRIPTION
See #16 

Basically allow custom validators added by `addValidator` to use `Validators.formatMessage` when the custom validator returns an object.