### PR TITLE
Supporting Immutable.js forms in confirmation validation

### DIFF
--- a/src/confirmation.js
+++ b/src/confirmation.js
@@ -1,10 +1,5 @@
 import Validators from './index'
-import { prepareMsg, prepare, memoize } from './helpers'
-
-// Duck-typing for Immutable.js to avoid dependencies
-const isImmutable = obj => (
-  obj.toJS && typeof obj.toJS === 'function'
-)
+import { prepareMsg, prepare, memoize, isImmutable } from './helpers'
 
 let confirmation = memoize(function ({
       field,

--- a/src/confirmation.js
+++ b/src/confirmation.js
@@ -1,6 +1,10 @@
 import Validators from './index'
 import { prepareMsg, prepare, memoize } from './helpers'
 
+// Duck-typing for Immutable.js to avoid dependencies
+const isImmutable = obj => (
+  obj.toJS && typeof obj.toJS === 'function'
+)
 
 let confirmation = memoize(function ({
       field,
@@ -13,7 +17,14 @@ let confirmation = memoize(function ({
   msg = msg || message
 
   return prepare(ifCond, unless, false, function (value, allValues) {
-    let fieldValue = '' + (allValues[field] || '')
+    let fieldValue;
+    
+    if (isImmutable(allValues)) {
+      fieldValue = allValues.getIn(field.split('.'))
+    } else {
+      fieldValue = '' + (allValues[field] || '')
+    }
+
     let cs = (null != caseSensitive ? caseSensitive : Validators.defaultOptions.caseSensitive)
 
     if (cs ? value !== fieldValue : value.toLowerCase() !== fieldValue.toLowerCase()) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -112,6 +112,11 @@ export function memoize (func) {
   }
 }
 
+// Duck-typing for Immutable.js to avoid dependencies
+export function isImmutable (obj) {
+  return obj.toJS && typeof obj.toJS === 'function'
+}
+
 // private
 const HAS_PROP = ({}).hasOwnProperty
 const TO_STRING = ({}).toString


### PR DESCRIPTION
Checking for Immutable.js values objects, and if so, loading the fieldValue using `.getIn`.

While I don't love duck typing, hopefully this isn't too egregious. 