### PR TITLE
Pass all available arguments from redux-form to addValidator

### DIFF
--- a/src/add-validator.js
+++ b/src/add-validator.js
@@ -9,8 +9,8 @@ export default function addValidator ({ validator, defaultMessage, defaultMsg })
   return memoize(function (options={}) {
     let msg = toObjectMsg(options.msg || options.message) || defaultMsg
 
-    return prepare(options.if, options.unless, options.allowBlank, function (value, allValues) {
-      let result = validator(options, value, allValues)
+    return prepare(options.if, options.unless, options.allowBlank, function (...args) {
+      let result = validator(options, ...args)
       if ('boolean' !== typeof result) {
         return result ? Validators.formatMessage(result) : null
       }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -29,7 +29,7 @@ export function regFormat (func, messageType) {
 
 
 export function prepare (ifCond, unlessCond, allowBlank, func) {
-  return function (value, allValues={}) {
+  return function (value, allValues={}, ...args) {
     if (!value || 'object' !== typeof value) {
       value = null == value ? '' : '' + value
 
@@ -39,7 +39,7 @@ export function prepare (ifCond, unlessCond, allowBlank, func) {
     }
     if (('function' !== typeof ifCond || ifCond(allValues, value)) &&
         ('function' !== typeof unlessCond || !unlessCond(allValues, value))) {
-      return func(value, allValues)
+      return func(value, allValues, ...args)
     }
   }
 }


### PR DESCRIPTION
Redux-form [validate](https://redux-form.com/7.3.0/docs/api/field.md/#-code-validate-value-allvalues-props-name-gt-error-code-optional-) method provides 4 arguments:
```
validate : (value, allValues, props, name) => error [optional]
```

They all should be passed to `addValidator` for implementing custom validation logic.

cc @gtournie