### PR TITLE
Add url.parseURL type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -188,7 +188,25 @@ export interface UrlValidatorOptions extends DefaultValidatorOptions {
   hash?: boolean
 }
 
-export const url: (options?: UrlValidatorOptions) => Validator
+interface URL {
+  protocol?: string;
+  hash?: string;
+  host?: string;
+  ipv4?: string;
+  ipv6?: string;
+  port?: number;
+  search?: string;
+  path?: string;
+  basicAuth?: {
+    username: string;
+    password?: string;
+  };
+}
+
+export const url : {
+  (options?: UrlValidatorOptions): Validator;
+  parseURL: (url: string, options?: UrlValidatorOptions) => URL | null;
+}
 
 declare const Validators: {
   formatMessage: (msg: MessageDescriptor) => string


### PR DESCRIPTION
Using

```typescript
import { addValidator, url } from "redux-form-validators";

// ...
  const info = url.parseURL(value, options);
// ...
```

was giving me the following error:

```
error TS2339: Property 'parseURL' does not exist on type '(options?: UrlValidatorOptions | undefined) => Validator'.

    const info = url.parseURL(value, options);
```

I extended `url`'s type definition to include `parseURL`. Not super sure about the `URL` type I added.