### PR TITLE
Update URL validation typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -186,6 +186,7 @@ export interface UrlValidatorOptions extends DefaultValidatorOptions {
   path?: boolean
   search?: boolean
   hash?: boolean
+  allowBlank?: boolean
 }
 
 export const url: (options?: UrlValidatorOptions) => Validator


### PR DESCRIPTION
Seems like "allowBlank" is a common validation flag so it can be moved to `DefaultValidatorOptions`.